### PR TITLE
Fixing bugs reported by customer

### DIFF
--- a/src/eventHandlers.ts
+++ b/src/eventHandlers.ts
@@ -16,14 +16,11 @@ import {
 } from './types/analytics';
 
 import {
-  hasPostAd,
   teardownAndRemove,
   framerateMap,
   toGetStreamType,
   toGetManifest
 } from './utils/helpers';
-
-import { toAdBreakNameDefault } from './utils/dataProjections';
 
 import {
   PlayerAPI,
@@ -140,17 +137,8 @@ export const toSourceFramerate = (player: PlayerAPI): number | undefined => {
 };
 
 // Core playback
-export const onVideoPlay = (
-  mediaHeartbeat: MediaHeartbeat,
-  player: PlayerAPI,
-  toCreateMediaObject: PlayerWithItemProjection<MediaObject, {}>,
-  toCustomMetadata: (player: PlayerAPI) => void,
-  started: () => void
-) => () => {
-  const mediaObject = toCreateMediaObject(player);
-  const contextData = toCustomMetadata(player);
-  mediaHeartbeat.trackSessionStart(mediaObject, Object(contextData));
-  started();
+export const onVideoPlay = (handler: () => void) => () => {
+  handler();
 };
 export const onVideoPlaying = (mediaHeartbeat: MediaHeartbeat) =>
   mediaHeartbeat.trackPlay;
@@ -162,10 +150,7 @@ export const toOnVideoComplete = (
   toCreateMediaObject: PlayerWithItemProjection<MediaObject, {}>,
   finished: () => void
 ) => () => {
-  mediaHeartbeat.trackEvent(Event.ChapterComplete);
-  if (!hasPostAd(player)) {
-    finished();
-  }
+  finished();
 };
 
 // Chapters and segments
@@ -255,9 +240,6 @@ export const toOnAdBreakComplete = (
   finished: () => void
 ) => () => {
   mediaHeartbeat.trackEvent(Event.AdBreakComplete);
-  if (toAdBreakNameDefault(player) === 'post') {
-    finished();
-  }
 };
 
 // QoS


### PR DESCRIPTION
- Fixed missng 'session start' event in case of auto-play
- Fixed and simplified handling of playback restart use case. In original logic, 'session end' and 'session start' was sent multiple times during restart
- Fixed sending 'Complete' event in case of 'adBreakComplete'. Original logic was checking if the ad is a post ad, then 'Complete' event was also sent. But it was found that 'PlaybackFinished' event from player is coming only after post roll ad is also played, so simply used the 'PlaybackFiished' event to trigger 'Complete'