### PR TITLE
Fix publishing of the initial version

### DIFF
--- a/build/publishNpmPackage.sh
+++ b/build/publishNpmPackage.sh
@@ -61,12 +61,12 @@ cd /bitmovin
 echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ~/.npmrc
 chmod 0600 ~/.npmrc
 
-# We need to make sure the script doesn't stop if this command fails, as it fails for example 
-# for the very first publish as the package doesn't exist on npm yet. 
-# In this case, $NPM_LATEST will have 'null' as value.
-set +e
-NPM_LATEST=$(npm view --json @bitmovin/player-integration-adobe dist-tags | jq -r ".${NPM_TAG}")
-set -e
+# The '|| echo null' ensures that in case of a failure of the previous commands we still get a
+# proper value in the variable. This may happen
+# a) if the package doesn't exist yet (i.e. this is the first release being published), or
+# b) the tag doesn't exist yet (e.g. the first beta release but the package already exists).
+# In such a case, $NPM_LATEST will have 'null' as value.
+NPM_LATEST=$(npm view --json @bitmovin/player-integration-adobe dist-tags | jq -r ".${NPM_TAG}" || echo null)
 
 echo "Latest version for tag '$NPM_TAG' on NPM: $NPM_LATEST"
 


### PR DESCRIPTION
Publishing of the first release didn't work because the publishing script broke as reading versions from NPM resulted in HTTP 404 errors as the package doesn't exist yet.

Fixed this by ensuring script doesn't stop if the NPM package doesn't exist yet.

Adding @jamdrop for his fabulous Bash skills to do a sanity check (or if there's a better way of doing this).

Here's the failed codeship build: https://app.codeship.com/projects/f666dbed-2783-41dc-b6c8-cc0de94c5413/builds/ef111610-2b7e-4b06-8e2e-99058dd55f3c?component=step_Publish_NPM_package