### PR TITLE
Ensure script keeps properly working if the package doesn't exist yet on NPM

### DIFF
--- a/build/publishNpmPackage.sh
+++ b/build/publishNpmPackage.sh
@@ -49,7 +49,7 @@ fi
 ## after fixing the problem, the npm publish would fail the build.
 IS_PUBLISHED=$(npm view @bitmovin/player-integration-adobe@${VERSION} dist-tags || echo "")
 
-if [[ ${IS_PUBLISHED} ]]; then
+if [[ "${IS_PUBLISHED}" != "" ]]; then
     echo "WARNING ${VERSION} is already published, skipping this step"
     exit 0
 else


### PR DESCRIPTION
Missed a case in the previous PR (#19) where the publishing script is also checking npm for details on the package.